### PR TITLE
Set default AWS region in GitHub Actions workflow

### DIFF
--- a/.github/workflows/github-actions-ec2.yml
+++ b/.github/workflows/github-actions-ec2.yml
@@ -34,6 +34,7 @@ jobs:
             python3.11 -m pip uninstall discord.py -y
             python3.11 -m pip uninstall py-cord -y
             python3.11 -m pip install py-cord
+            aws configure set default.region us-east-1
             aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             aws s3 cp s3://${{ secrets.SECRET_BUCKET }}/.env .


### PR DESCRIPTION
Configure the default AWS region to ensure consistent behavior in the workflow.