### PR TITLE
ci: serialize SST deploys with a concurrency group

### DIFF
--- a/.github/workflows/sst-deploy.yml
+++ b/.github/workflows/sst-deploy.yml
@@ -7,6 +7,9 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: sst-deploy-production
+
 jobs:
   DeployApp:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Queues SST deploys so a run waits for the previous one to finish instead of racing it on the shared state lock.

Matches the pattern already in pwnpro.com; applied to the other SST repos in the same pass.